### PR TITLE
replaced Google Analytics tracking number

### DIFF
--- a/_site.yml
+++ b/_site.yml
@@ -3,7 +3,7 @@ title: "Environments"
 description: |
   Environments
 output_dir: "_site"
-google_analytics: "UA-20375833-24"
+google_analytics: "UA-20375833-3"
 navbar:
   right:
     - text: "Use Cases"


### PR DESCRIPTION
@slopp 
I’ve replaced your Google Analytics tracking number with the one for rstudio.com, which enables us to track users across domains.  Your site’s analytics will now be found under the rstudio.com property and I have built a segment for you to view your site’s metrics separate from other domains.  Data will populate from today forward and you will need to visit your previous property for historical data.  Thank you for merging this pull request so that we can get a full picture of online user behavior.